### PR TITLE
For stm32-cube-f4-toolchain, add toolchain submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bsp/stm32f4-toolchain"]
+	path = bsp/stm32f4-toolchain
+	url = git@github.com:ahasanbegovic/stm32cube-f4-cmake-toolchain.git


### PR DESCRIPTION
# stm32-cube-f4-toolchain
- Add toolchain as a submodule